### PR TITLE
fix bug

### DIFF
--- a/src/ui/Input.js
+++ b/src/ui/Input.js
@@ -116,7 +116,7 @@ define(function(require) {
     function isInput(elem) {
         return elem.nodeType === 1 &&
             elem.tagName.toLowerCase() === 'input' &&
-            elem.getAttribute('type').toLowerCase() === 'text';
+            (!elem.getAttribute('type') || elem.getAttribute('type').toLowerCase() === 'text');
     }
 
     var dataKey = 'bizInput';


### PR DESCRIPTION
jquery1.5.2后，如果input标签没有写type＝“text”，那么:text选择器仍然会选中该input
